### PR TITLE
Override PYTHONHOME and add "python" command.

### DIFF
--- a/ilastik.bat.in
+++ b/ilastik.bat.in
@@ -25,13 +25,22 @@ rem set more paths
 set QTDIR=%INSTALL_DIR%Qt4
 IF ["%ILASTIK_DIR%"] EQU [""] set ILASTIK_DIR=%INSTALL_DIR%ilastik
 set PYTHONPATH=%ILASTIK_DIR%\lazyflow;%ILASTIK_DIR%\volumina;%ILASTIK_DIR%\ilastik
+set PYTHONHOME=%INSTALL_DIR%\python
 
 rem check if this script was called as 'lastik test'
 if /I "%1" EQU "test" goto :testing
+if /I "%1" EQU "python" goto :python
  
 rem if not, start ilastik normally
 echo Loading ilastik from "%ILASTIK_DIR%"
 "%INSTALL_DIR%python\python" "%ILASTIK_DIR%\ilastik\ilastik.py" %*
+goto :end
+
+:python
+echo ----------------------------
+echo Running python command...
+"%INSTALL_DIR%python\python" %*
+
 goto :end
 
 :testing


### PR DESCRIPTION
If the user already has `PYTHONHOME` set, the binary fails since it cannot use
the python libraries we ship. To overcome this problem, as seen in 
ilastik/ilastik#1067, we override the `PYTHONHOME` environment variable.

This patch also adds a "python" argument to `ilastik.bat` that allows running
Python scripts within the same environment ilastik is run.